### PR TITLE
Fix duplicate SQL queries executed by the collection plugin

### DIFF
--- a/Plugin/Catalog/Model/ResourceModel/Product/Fulltext/CollectionPlugin.php
+++ b/Plugin/Catalog/Model/ResourceModel/Product/Fulltext/CollectionPlugin.php
@@ -47,6 +47,11 @@ class CollectionPlugin
     private $storeManager;
 
     /**
+     * @var boolean[]
+     */
+    private $sharedCatalogStatusByGroup = [];
+
+    /**
      * Constructor.
      *
      * @param \Magento\Company\Model\CompanyContext                $companyContext          Company context.
@@ -125,10 +130,14 @@ class CollectionPlugin
      */
     private function isActive($customerGroupId)
     {
-        $websiteId                = $this->storeManager->getWebsite()->getId();
-        $isActive                 = $this->config->isActive(ScopeInterface::SCOPE_WEBSITE, $websiteId);
-        $isMasterCatalogAvailable = $this->customerGroupManagement->isMasterCatalogAvailable($customerGroupId);
+        if (!isset($this->sharedCatalogStatusByGroup[$customerGroupId])) {
+            $websiteId                = $this->storeManager->getWebsite()->getId();
+            $isActive                 = $this->config->isActive(ScopeInterface::SCOPE_WEBSITE, $websiteId);
+            $isMasterCatalogAvailable = $this->customerGroupManagement->isMasterCatalogAvailable($customerGroupId);
 
-        return $isActive && !$isMasterCatalogAvailable;
+            $this->sharedCatalogStatusByGroup[$customerGroupId] = $isActive && !$isMasterCatalogAvailable;
+        }
+
+        return $this->sharedCatalogStatusByGroup[$customerGroupId];
     }
 }


### PR DESCRIPTION
Hi,

This PR aims to fix a performance issue related to the collection plugin.

On the category page, we found out that the following query was executed more than 100 times:

```sql
SELECT `customer_group`.`customer_group_id` FROM `customer_group`
LEFT JOIN `shared_catalog`
ON customer_group.customer_group_id = shared_catalog.customer_group_id
WHERE ((shared_catalog.entity_id IS NULL AND customer_group.customer_group_id != 0))
```

It's caused by the following plugin:
https://github.com/Smile-SA/magento2-module-elasticsuite-shared-catalog/blob/master/Plugin/Catalog/Model/ResourceModel/Product/Fulltext/CollectionPlugin.php#L130

The method "isMasterCatalogAvailable" doesn't cache its result, it always re-execute a SQL query when it is called.
The fix is to cache the result of the function.

PS: the fail on travis doesn't seem to be related to my modifications.