### PR TITLE
check if collection is loaded first to avoid repetitive calls to isActive

### DIFF
--- a/Plugin/Catalog/Model/ResourceModel/Product/Fulltext/CollectionPlugin.php
+++ b/Plugin/Catalog/Model/ResourceModel/Product/Fulltext/CollectionPlugin.php
@@ -109,7 +109,7 @@ class CollectionPlugin
     {
         $customerGroupId = $this->companyContext->getCustomerGroupId();
 
-        if ($this->isActive($customerGroupId) && !$collection->isLoaded()) {
+        if (!$collection->isLoaded() && $this->isActive($customerGroupId)) {
             $collection->addFieldToFilter("customer_group_id", $customerGroupId);
         }
 


### PR DESCRIPTION
On search result or category page, I noticed more than 1000 calls to 
Smile\ElasticsuiteSharedCatalog\Plugin\Catalog\Model\ResourceModel\Product\Fulltext::isActive and SQL query
`
select ? from customer_group left join shared_catalog on customer_group.customer_group_id = shared_catalog.customer_group_id where ((shared_catalog.entity_id is null and customer_group.customer_group_id != ?))
`
![image](https://user-images.githubusercontent.com/53449841/106647034-6ae94080-655c-11eb-839f-7521b0921679.png)

This is slowing down server response time, this PR resolves the issue by checking if collection isLoaded before checking on isActive