### PR TITLE
Updating compatibility with ElasticSuite 2.11

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -15,6 +15,8 @@
 namespace Smile\ElasticsuiteSharedCatalog\Helper;
 
 use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\App\Helper\Context;
+use Magento\Framework\Module\Manager as ModuleManager;
 
 /**
  * ElasticSuite Shared Catalog Helper
@@ -26,20 +28,21 @@ use Magento\Framework\App\Helper\AbstractHelper;
 class Data extends AbstractHelper
 {
     /**
-     * @var \Magento\Framework\Module\Manager
+     * @var ModuleManager
      */
-    private $moduleManager;
+    private ModuleManager $moduleManager;
 
     /**
      * Constructor.
      *
-     * @param \Magento\Framework\App\Helper\Context $context       Context.
-     * @param \Magento\Framework\Module\Manager     $moduleManager Module manager.
+     * @param Context       $context        Context.
+     * @param ModuleManager $moduleManager  Module manager.
      */
     public function __construct(
-        \Magento\Framework\App\Helper\Context $context,
-        \Magento\Framework\Module\Manager $moduleManager
-    ) {
+        Context       $context,
+        ModuleManager $moduleManager
+    )
+    {
         parent::__construct($context);
         $this->moduleManager = $moduleManager;
     }
@@ -49,7 +52,7 @@ class Data extends AbstractHelper
      *
      * @return boolean
      */
-    public function isEnabled()
+    public function isEnabled(): bool
     {
         return $this->moduleManager->isEnabled("Magento_SharedCatalog");
     }

--- a/Model/Product/Indexer/Fulltext/Datasource/SharedCatalog.php
+++ b/Model/Product/Indexer/Fulltext/Datasource/SharedCatalog.php
@@ -30,12 +30,12 @@ class SharedCatalog implements DatasourceInterface
     /**
      * @var SharedCatalogHelper
      */
-    private $helper;
+    private SharedCatalogHelper $helper;
 
     /**
      * @var ResourceModel
      */
-    private $resourceModel;
+    private ResourceModel $resourceModel;
 
     /**
      * Constructor.
@@ -43,7 +43,10 @@ class SharedCatalog implements DatasourceInterface
      * @param SharedCatalogHelper $helper        ElasticSuite Shared Catalog helper.
      * @param ResourceModel       $resourceModel Resource model.
      */
-    public function __construct(SharedCatalogHelper $helper, ResourceModel $resourceModel)
+    public function __construct(
+        SharedCatalogHelper $helper,
+        ResourceModel $resourceModel
+    )
     {
         $this->helper        = $helper;
         $this->resourceModel = $resourceModel;

--- a/Model/Product/Search/Request/Container/Filter/CustomerGroup.php
+++ b/Model/Product/Search/Request/Container/Filter/CustomerGroup.php
@@ -35,32 +35,32 @@ class CustomerGroup implements FilterInterface
     /**
      * @var QueryFactory
      */
-    private $queryFactory;
+    private QueryFactory $queryFactory;
 
     /**
      * @var CompanyContext
      */
-    private $companyContext;
+    private CompanyContext $companyContext;
 
     /**
      * @var Config
      */
-    private $config;
+    private Config $config;
 
     /**
      * @var CustomerGroupManagement
      */
-    private $customerGroupManagement;
+    private CustomerGroupManagement $customerGroupManagement;
 
     /**
      * @var StoreManagerInterface
      */
-    private $storeManager;
+    private StoreManagerInterface $storeManager;
 
     /**
      * @var boolean[]
      */
-    private $sharedCatalogStatusByGroup = [];
+    private array $sharedCatalogStatusByGroup = [];
 
     /**
      * Customer group filter constructor.

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "magento/module-catalog-search": ">=101.0.0",
     "magento/module-shared-catalog": ">=100.1.0",
     "magento/magento-composer-installer": "*",
-    "smile/elasticsuite": "~2.10.0"
+    "smile/elasticsuite": "~2.11.0"
   },
   "require-dev": {
      "smile/magento2-smilelab-quality-suite": "^1.1.0"


### PR DESCRIPTION
# What was the issue
B2B store upgrading to 2.4.6 was not able to get the shared catalog and the quickorder to install due to compose dependencies

# What was done
- Small changes to get better compatibility with PHP 8.x 
- Updated composer to be compatible with ElasticSuite 2.11